### PR TITLE
feat: add EnergyWebFoundation Volta network

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,12 @@ const providerConfig = {
       chainId: '0x03c401',
       rpcUrl: 'https://rpc.tau1.artis.network'
     },
+    {
+      name: 'volta',
+      chainId: '73799',
+      rpcUrl: 'https://volta-rpc.energyweb.org',
+      registry: '0xc15d5a57a8eb0e1dcbe5d88b8f9a82017e5cc4af',
+    },
 //    {
 //      name: 'matic',
 //      chainId: 137,


### PR DESCRIPTION
Hello! My name is John Henderson. I'm a software engineer at the [Energy Web Foundation](https://www.energyweb.org/). We have adopted the `ethr` DID method for our SSI use cases. This PR is a request to add configuration to resolve `ethr` DIDs from our Energy Web "Volta" test chain. 
My understanding is that this change would eventually get built into the uport/uni-resolver-driver-did-uport docker image and would be then included in the universal resolver. Is this correct?