### PR TITLE
feat: add EnergyWebFoundation EWC network

### DIFF
--- a/src/__tests__/ethr.test.js
+++ b/src/__tests__/ethr.test.js
@@ -248,6 +248,20 @@ describe('did:ethr driver', () => {
       expect(response.body.didDocument).toHaveProperty('verificationMethod')
     })
 
+
+    it('did:ethr:volta:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736', async () => {
+      expect.assertions(1)
+      const did = 'did:ethr:volta:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736'
+      const response = await request(app).get(`/1.0/identifiers/${did}`)
+      expect(response.body.didDocument).toHaveProperty('verificationMethod')
+    })
+    
+    it('did:ethr:0x12047:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736', async () => {
+      expect.assertions(1)
+      const did = 'did:ethr:0x12047:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736'
+      const response = await request(app).get(`/1.0/identifiers/${did}`)
+      expect(response.body.didDocument).toHaveProperty('verificationMethod')
+    })
     it('did:ethr:ewc:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736', async () => {
       expect.assertions(1)
       const did = 'did:ethr:ewc:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736'

--- a/src/__tests__/ethr.test.js
+++ b/src/__tests__/ethr.test.js
@@ -247,6 +247,20 @@ describe('did:ethr driver', () => {
       const response = await request(app).get(`/1.0/identifiers/${did}`)
       expect(response.body.didDocument).toHaveProperty('verificationMethod')
     })
+
+    it('did:ethr:ewc:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736', async () => {
+      expect.assertions(1)
+      const did = 'did:ethr:ewc:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736'
+      const response = await request(app).get(`/1.0/identifiers/${did}`)
+      expect(response.body.didDocument).toHaveProperty('verificationMethod')
+    })
+    
+    it('did:ethr:0xf6:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736', async () => {
+      expect.assertions(1)
+      const did = 'did:ethr:0xf6:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736'
+      const response = await request(app).get(`/1.0/identifiers/${did}`)
+      expect(response.body.didDocument).toHaveProperty('verificationMethod')
+    })
   })
 
   describe('responds with error for', () => {

--- a/src/app.js
+++ b/src/app.js
@@ -20,13 +20,13 @@ const providerConfig = {
     },
     {
       name: 'volta',
-      chainId: '73799',
+      chainId: '0x12047',
       rpcUrl: 'https://volta-rpc.energyweb.org',
       registry: '0xc15d5a57a8eb0e1dcbe5d88b8f9a82017e5cc4af',
     },
     {
       name: 'ewc',
-      chainId: '246',
+      chainId: '0xf6',
       rpcUrl: 'https://rpc.energyweb.org',
       registry: '0xE29672f34e92b56C9169f9D485fFc8b9A136BCE4',
     },

--- a/src/app.js
+++ b/src/app.js
@@ -24,6 +24,12 @@ const providerConfig = {
       rpcUrl: 'https://volta-rpc.energyweb.org',
       registry: '0xc15d5a57a8eb0e1dcbe5d88b8f9a82017e5cc4af',
     },
+    {
+      name: 'ewc',
+      chainId: '246',
+      rpcUrl: 'https://rpc.energyweb.org',
+      registry: '0xE29672f34e92b56C9169f9D485fFc8b9A136BCE4',
+    },
 //    {
 //      name: 'matic',
 //      chainId: 137,


### PR DESCRIPTION
This PR adds the Energy Web Foundations EWC network to the list of default networks.

Tested by running:
```
npm run start
```
Then
```
curl -X GET http://localhost:8081/1.0/identifiers/did:ethr:ewc:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736
```